### PR TITLE
Add title search across all variations with dedicated search route (#1)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -36,6 +36,7 @@ $router->map('GET', '/', function (ServerRequestInterface $request): ResponseInt
 $router->map('GET', '/articles/todays-changed', [ArticleController::class, 'getTodaysChangedArticles']);
 $router->map('GET', '/articles/frequently-changed', [ArticleController::class, 'getFrequentlyChangedArticles']);
 $router->map('GET', '/articles/category/{category}', [ArticleController::class, 'getCategoryArticles']);
+$router->map('GET', '/articles/search', [ArticleController::class, 'searchArticles']);
 $router->map('GET', '/article/{guid}', [ArticleController::class, 'getArticle']);
 $router->map('GET', '/categories', [CategoryController::class, 'getCategories']);
 

--- a/src/Http/ArticleController.php
+++ b/src/Http/ArticleController.php
@@ -86,4 +86,22 @@ class ArticleController
 
         return $response;
     }
+
+    public function searchArticles(ServerRequestInterface $request): ResponseInterface
+    {
+        $queryParams = $request->getQueryParams();
+        $query = $queryParams['q'] ?? '';
+
+        $articles = [];
+        if (!empty($query)) {
+            $articles = iterator_to_array($this->articleRepository->searchArticles($query));
+        }
+
+        $response = (new Response())
+            ->withHeader('Content-Type', 'application/json');
+
+        $response->getBody()->write($this->serializer->serialize($articles, 'json'));
+
+        return $response;
+    }
 }

--- a/src/Repository/ArticleRepository.php
+++ b/src/Repository/ArticleRepository.php
@@ -230,4 +230,40 @@ class ArticleRepository
             yield ArticleTestTitle::fromDatabaseRow($row);
         }
     }
+
+    public function searchArticles(string $query): \Generator
+    {
+        // Escape SQL wildcards to prevent unwanted pattern matching
+        $escapedQuery = str_replace(['%', '_'], ['\\%', '\\_'], $query);
+        $searchTerm = '%' . $escapedQuery . '%';
+        
+        $stmt = $this->pdo->prepare(
+            'SELECT DISTINCT articles.*, 
+                COUNT(DISTINCT article_titles.id) AS num_titles,
+                COUNT(DISTINCT article_test_titles.id) AS num_test_titles
+             FROM articles
+             LEFT OUTER JOIN article_titles ON (article_titles.article_id = articles.id)
+             LEFT OUTER JOIN article_test_titles ON (article_test_titles.article_id = articles.id)
+             WHERE articles.title LIKE :search
+                OR EXISTS (
+                    SELECT 1 FROM article_titles 
+                    WHERE article_titles.article_id = articles.id 
+                    AND article_titles.title LIKE :search
+                )
+                OR EXISTS (
+                    SELECT 1 FROM article_test_titles 
+                    WHERE article_test_titles.article_id = articles.id 
+                    AND article_test_titles.title LIKE :search
+                )
+             GROUP BY articles.id
+             ORDER BY articles.created_at DESC
+             LIMIT 50'
+        );
+
+        $stmt->execute(['search' => $searchTerm]);
+
+        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+            yield Article::fromDatabaseRow($row);
+        }
+    }
 }

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   export let data;
 
   let inputArticleUrl: string;
+  let searchQuery: string | undefined = undefined;
 
   const debaitButtonClicked = async () => {
     // Parse the URL to get the GUID from it
@@ -22,6 +23,12 @@
     }
   };
 
+  const handleSearch = async () => {
+    if (searchQuery?.trim()) {
+      await goto(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
+    }
+  };
+
   const tagLine = 'See beyond the veil and expose the true agenda';
   $og = {
     ...DEFAULT_OG,
@@ -35,11 +42,31 @@
 </div>
 
 <div class="pure-u-1-1 l-box">
-  Paste a link to an article:
-  <form on:submit|preventDefault={debaitButtonClicked}>
-    <input type="text" bind:value={inputArticleUrl} />
-    <button>Debait</button>
-  </form>
+  <div class="pure-g">
+    <div class="pure-u-1 pure-u-sm-1-2">
+      <div class="paste-section">
+        Paste a link to an article:
+        <form on:submit|preventDefault={debaitButtonClicked}>
+          <input type="text" bind:value={inputArticleUrl} style="width: 100%; max-width: 300px;" />
+          <button>Debait</button>
+        </form>
+      </div>
+    </div>
+    <div class="pure-u-1 pure-u-sm-1-2">
+      <div class="search-section">
+        Search for articles by title (any variation):
+        <form on:submit|preventDefault={handleSearch}>
+          <input
+            type="text"
+            bind:value={searchQuery}
+            placeholder="Search for any title..."
+            style="width: 100%; max-width: 300px;"
+          />
+          <button>Search</button>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="pure-u-1-1 l-box">

--- a/webui/src/routes/search/+page.svelte
+++ b/webui/src/routes/search/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { APP_NAME, DEFAULT_OG, og } from '$lib/seo';
+  import ArticleSummary from '$lib/components/ArticleSummary.svelte';
+
+  export let data;
+
+  let searchQuery: string = data.searchQuery;
+
+  const handleSearch = async () => {
+    if (searchQuery?.trim()) {
+      await goto(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
+    } else {
+      await goto('/');
+    }
+  };
+
+  const tagLine = 'See beyond the veil and expose the true agenda';
+  $og = {
+    ...DEFAULT_OG,
+    description: `Search results for "${data.searchQuery}" - ${tagLine}`
+  };
+</script>
+
+<div class="pure-u-1-1 l-box">
+  <h1 style="margin-bottom: 0;">{APP_NAME}</h1>
+  <p>{tagLine} &#128517;</p>
+</div>
+
+<div class="pure-u-1-1 l-box">
+  <div class="pure-g">
+    <div class="pure-u-1">
+      Search for articles by title (any variation):
+      <form on:submit|preventDefault={handleSearch}>
+        <input
+          type="text"
+          bind:value={searchQuery}
+          placeholder="Search for any title..."
+          style="width: 100%; max-width: 300px;"
+        />
+        <button>Search</button>
+        <a href="/" style="margin-left: 0.5em;">Back to main page</a>
+      </form>
+    </div>
+  </div>
+</div>
+
+<div class="pure-u-1-1 l-box">
+  <h2>Search Results for "{data.searchQuery}"</h2>
+  {#if data.searchResults.length > 0}
+    <ul>
+      {#each data.searchResults as article}
+        <li>
+          <ArticleSummary {article}></ArticleSummary>
+        </li>
+      {/each}
+    </ul>
+  {:else}
+    <p>No articles found matching your search.</p>
+  {/if}
+</div>

--- a/webui/src/routes/search/+page.ts
+++ b/webui/src/routes/search/+page.ts
@@ -1,0 +1,26 @@
+import type { PageLoad } from './$types';
+import { env } from '$env/dynamic/public';
+import { redirect } from '@sveltejs/kit';
+
+export const load: PageLoad = async ({ fetch, url }) => {
+  const searchQuery = url.searchParams.get('q');
+
+  if (!searchQuery?.trim()) {
+    throw redirect(302, '/');
+  }
+
+  let searchResults = [];
+  try {
+    const response = await fetch(
+      `${env.PUBLIC_API_BASE_URL}/articles/search?q=${encodeURIComponent(searchQuery)}`
+    );
+    if (response.ok) {
+      searchResults = await response.json();
+    }
+  } catch (err) {
+    console.error('Search failed:', err);
+    // searchResults remains empty on error
+  }
+
+  return { searchQuery, searchResults };
+};

--- a/webui/src/routes/styles.css
+++ b/webui/src/routes/styles.css
@@ -34,3 +34,22 @@ nav {
 .l-box {
   padding: 1em;
 }
+
+.paste-section {
+  padding-right: 0.5em;
+}
+
+.search-section {
+  padding-left: 0.5em;
+}
+
+@media screen and (max-width: 567px) {
+  .paste-section {
+    padding-right: 0;
+  }
+
+  .search-section {
+    padding-left: 0;
+    margin-top: 1em;
+  }
+}


### PR DESCRIPTION
* Initial plan

* Add search functionality for article titles



* Format code with Prettier



* Add error handling and escape SQL wildcards in search



* Fix PDO named parameter binding



* Reorganize layout: side-by-side on desktop, keep paste link visible, add clear button



* Match styling between paste link and search sections



* Fix alignment and spacing when layout wraps to two lines



* Fix layout to be side-by-side on larger screens and properly aligned on mobile



* Refactor search to use separate route and undefined for empty query



* Improve search UX: redirect instead of error, add back to main link



* Handle whitespace-only search queries with redirect



---------